### PR TITLE
Fixed path to actual github repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,7 @@ Note: This is the legacy interface, please check out
 Net::Amazon::S3::Client instead.
 
 Development of this code happens here:
-http://github.com/pfig/net-amazon-s3/
-
-Homepage for the project (just started) is at
-http://pfig.github.com/net-amazon-s3/
+https://github.com/rustyconover/net-amazon-s3
 
 # LICENSE
 

--- a/lib/Net/Amazon/S3.pm
+++ b/lib/Net/Amazon/S3.pm
@@ -101,9 +101,7 @@ in buckets. Bucket names are global.
 Note: This is the legacy interface, please check out
 L<Net::Amazon::S3::Client> instead.
 
-Development of this code happens here: http://github.com/pfig/net-amazon-s3/
-
-Homepage for the project (just started) is at http://pfig.github.com/net-amazon-s3/
+Development of this code happens here: https://github.com/rustyconover/net-amazon-s3
 
 =cut
 

--- a/lib/Net/Amazon/S3/Client/Bucket.pm
+++ b/lib/Net/Amazon/S3/Client/Bucket.pm
@@ -75,6 +75,7 @@ sub list {
     my ( $self, $conf ) = @_;
     $conf ||= {};
     my $prefix = $conf->{prefix};
+    my $delimiter = $conf->{delimiter};
 
     my $marker = undef;
     my $end    = 0;
@@ -89,6 +90,7 @@ sub list {
                 bucket => $self->name,
                 marker => $marker,
                 prefix => $prefix,
+                delimiter => $delimiter,
             )->http_request;
 
             my $xpc = $self->client->_send_request_xpc($http_request);
@@ -246,6 +248,11 @@ This module represents buckets.
 
   # or list by a prefix
   my $prefix_stream = $bucket->list( { prefix => 'logs/' } );
+
+  # you can emulate folders by using prefix with delimiter
+  # which shows only entries starting with the prefix but
+  # not containing any more delimiter (thus no subfolders).
+  my $folder_stream = $bucket->list( { prefix => 'logs/', delimiter => '/' } );
 
 =head2 location_constraint
 


### PR DESCRIPTION
and removed reference to out-dated homepage.

Rusty, since your dist.ini has the correct entry, why is metacpan still referencing the pfig github?