### PR TITLE
Added support for virtual hosts buckets

### DIFF
--- a/lib/Net/Amazon/S3.pm
+++ b/lib/Net/Amazon/S3.pm
@@ -144,6 +144,7 @@ has 'secure' => ( is => 'ro', isa => 'Bool', required => 0, default => 0 );
 has 'timeout' => ( is => 'ro', isa => 'Num',  required => 0, default => 30 );
 has 'retry'   => ( is => 'ro', isa => 'Bool', required => 0, default => 0 );
 has 'host'    => ( is => 'ro', isa => 'Str',  required => 0, default => 's3.amazonaws.com' );
+has 'virtual_host' => ( is => 'rw', isa => 'Bool', required => 0, default => 0 );
 
 has 'libxml' => ( is => 'rw', isa => 'XML::LibXML',    required => 0 );
 has 'ua'     => ( is => 'rw', isa => 'LWP::UserAgent', required => 0 );
@@ -211,6 +212,15 @@ as recommended by Amazon. Defaults to off.
 
 The S3 host endpoint to use. Defaults to 's3.amazonaws.com'. This allows
 you to connect to any S3-compatible host.
+
+=back
+
+=item virtual_host
+
+Use the virtual host method ('bucketname.s3.amazonaws.com') instead of specifying the
+bucket at the first part of the path. This is particularily useful if you want to access
+buckets not located in the US-Standard region (such as EU, Asia Pacific or South America).
+See L<http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html> for the pros and cons.
 
 =back
 

--- a/lib/Net/Amazon/S3/HTTPRequest.pm
+++ b/lib/Net/Amazon/S3/HTTPRequest.pm
@@ -44,6 +44,12 @@ sub http_request {
         unless exists $headers->{Authorization};
     my $protocol = $self->s3->secure ? 'https' : 'http';
     my $host = $self->s3->host;
+    if ($self->s3->virtual_host) {
+        # use https://bucketname.s3.amazonaws.com instead of https://s3.amazonaws.com/bucketname
+        # see http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html
+        $path =~ s{(.*?)/}{} and my $bucket = $1;
+        $host = "$bucket.$host";
+    }
     my $uri = "$protocol://$host/$path";
 
     my $request
@@ -72,6 +78,12 @@ sub query_string_authentication_uri {
 
     my $protocol = $self->s3->secure ? 'https' : 'http';
     my $host = $self->s3->host;
+    if ($self->s3->virtual_host) {
+        # use https://bucketname.s3.amazonaws.com instead of https://s3.amazonaws.com/bucketname
+        # see http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html
+        $path =~ s{(.*?)/}{} and my $bucket = $1;
+        $host = "$bucket.$host";
+    }
     my $uri = "$protocol://$host/$path";
 
     $uri = URI->new($uri);


### PR DESCRIPTION
which allows transparent access to buckets outside the US-Standard region
by looking up the region via DNS.

Rusty, this looks a bit like a hack. However, I have put some thought into this, e.g. adjusting the path method to not return the bucket name, and rather pass the bucketname into the constructor also. That said, this approach has the least impact on anything and should work reliably.

It does work in my test environment, where I can now switch between buckets of various regions without any changes to the host.