### PR TITLE
Performance improvements:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pm_to_blib
 *.gz
 .build
 *~
+*.swp

--- a/lib/Net/Amazon/S3.pm
+++ b/lib/Net/Amazon/S3.pm
@@ -214,6 +214,14 @@ you to connect to any S3-compatible host.
 
 =back
 
+When using L<Net::Amazon::S3> in child processes using fork (such as in
+combination with the excellent L<Parallel::ForkManager>) you should create the
+S3 object in each child, use a fresh LWP::UserAgent in each child, or disable
+the L<LWP::ConnCache> in the parent:
+
+    $s3->ua( LWP::UserAgent->new( 
+        keep_alive => 0, requests_redirectable => [qw'GET HEAD DELETE PUT POST'] );
+
 =cut
 
 sub BUILD {

--- a/lib/Net/Amazon/S3/Client/Bucket.pm
+++ b/lib/Net/Amazon/S3/Client/Bucket.pm
@@ -113,7 +113,7 @@ sub list {
                     client => $self->client,
                     bucket => $self,
                     key    => $xpc->findvalue( './s3:Key', $node ),
-                    last_modified =>
+                    last_modified_raw =>
                         $xpc->findvalue( './s3:LastModified', $node ),
                     etag => $etag,
                     size => $xpc->findvalue( './s3:Size', $node ),


### PR DESCRIPTION
- making DateTime coercion optional for last_modified (something that
  might happen million of times without ever been used, in a rather
  expensive operation)
- avoiding MD5 calculation of large files (chunked uploads) that
  are then never used

Mentioned proper use of S3 object and LWP::ConnCache in forked
environments


Rusty, these are two of the performance bottle necks I ran into when having to deal with a couple million files, some of which are quite large. For the last_modified change I tried to be as backwards compatible as possible. We could further improve this if we would do the coercion ourselves, avoiding DateTimeX::Easy, however, for my purposes using the raw string actually works best.