### PR TITLE
Completed HEAD and aborting multipart uploads

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,0 +1,3 @@
+# Very simple stub because of damn Dist::Zilla
+use ExtUtils::MakeMaker;
+WriteMakefile( 'PL_FILES' => {}, 'VERSION' => '0.01', 'EXE_FILES' => [] );

--- a/lib/Net/Amazon/S3.pm
+++ b/lib/Net/Amazon/S3.pm
@@ -129,6 +129,7 @@ use Net::Amazon::S3::Request::ListAllMyBuckets;
 use Net::Amazon::S3::Request::ListMultipartUploads;
 use Net::Amazon::S3::Request::ListBucket;
 use Net::Amazon::S3::Request::ListParts;
+use Net::Amazon::S3::Request::ListVersions;
 use Net::Amazon::S3::Request::PutObject;
 use Net::Amazon::S3::Request::PutPart;
 use Net::Amazon::S3::Request::SetBucketAccessControl;

--- a/lib/Net/Amazon/S3/Bucket.pm
+++ b/lib/Net/Amazon/S3/Bucket.pm
@@ -423,6 +423,32 @@ sub list_all {
     return $self->account->list_bucket_all($conf);
 }
 
+=head2 list_uploads
+
+List all unfinished multi-part uploads, e.g. to clear out stale ones.
+
+=cut
+
+sub list_uploads {
+    my ($self) = shift;
+    my $conf = shift || {};
+    $conf->{bucket} = $self->bucket;
+    return $self->account->list_uploads($conf);
+}
+
+=head2 abort_multipart_upload
+
+Remove a pending upload, thus freeing the storage
+
+=cut
+
+sub abort_multipart_upload {
+    my ($self) = shift;
+    my $conf = shift || {};
+    $conf->{bucket} = $self->bucket;
+    return $self->account->abort_multipart_upload($conf);
+}
+
 =head2 get_acl
 
 Takes one optional positional parameter

--- a/lib/Net/Amazon/S3/Client.pm
+++ b/lib/Net/Amazon/S3/Client.pm
@@ -89,7 +89,7 @@ sub _send_request {
     my $code         = $http_response->code;
 
     if ( is_error($code) ) {
-        if ( $content_type eq 'application/xml' ) {
+        if ( $content_type eq 'application/xml' and length $content ) {
             my $doc = $self->s3->libxml->parse_string($content);
             my $xpc = XML::LibXML::XPathContext->new($doc);
             $xpc->registerNs( 's3',

--- a/lib/Net/Amazon/S3/Client/Bucket.pm
+++ b/lib/Net/Amazon/S3/Client/Bucket.pm
@@ -137,6 +137,90 @@ sub list {
     );
 }
 
+sub versions {
+    my ( $self, $conf ) = @_;
+    $conf ||= {};
+    my $prefix = $conf->{prefix};
+    my $delimiter = $conf->{delimiter};
+
+    my $marker = undef;
+    my $end    = 0;
+
+    return Data::Stream::Bulk::Callback->new(
+        callback => sub {
+
+            return undef if $end;
+
+            my $http_request = Net::Amazon::S3::Request::ListVersions->new(
+                s3     => $self->client->s3,
+                bucket => $self->name,
+                marker => $marker,
+                prefix => $prefix,
+                delimiter => $delimiter,
+            )->http_request;
+            
+            my $xpc = $self->client->_send_request_xpc($http_request);
+
+            my @objects;
+            foreach my $node (
+                $xpc->findnodes('/s3:ListVersionsResult/s3:Version') ) {
+                my $etag = $xpc->findvalue( "./s3:ETag", $node );
+                $etag =~ s/^"//;
+                $etag =~ s/"$//;
+
+                my $obj =
+                    $self->object_class->new(
+                    client => $self->client,
+                    bucket => $self,
+                    key    => $xpc->findvalue( './s3:Key', $node ),
+                    last_modified_raw =>
+                        $xpc->findvalue( './s3:LastModified', $node ),
+                    etag => $etag,
+                    size => $xpc->findvalue( './s3:Size', $node ),
+                    );
+                $obj->user_metadata->{version_id} = $xpc->findvalue('./s3:VersionId', $node);
+                $obj->user_metadata->{is_latest} = $xpc->findvalue('./s3:IsLatest', $node);
+                push @objects, $obj;
+            }
+            foreach my $node (
+                $xpc->findnodes('/s3:ListVersionResult/s3:DeleteMarker') ) {
+                my $etag = $xpc->findvalue( "./s3:ETag", $node );
+                $etag =~ s/^"//;
+                $etag =~ s/"$//;
+
+                my $obj =
+                    $self->object_class->new(
+                    client => $self->client,
+                    bucket => $self,
+                    key    => $xpc->findvalue( './s3:Key', $node ),
+                    last_modified_raw =>
+                        $xpc->findvalue( './s3:LastModified', $node ),
+                    etag => '',
+                    size => -1,
+                    );
+                $obj->user_metadata->{version_id} = $xpc->findvalue('./s3:VersionId', $node);
+                $obj->user_metadata->{is_latest} = $xpc->findvalue('./s3:IsLatest', $node);
+                $obj->user_metadata->{delete_marker} = 1;
+                push @objects, $obj;
+            }
+
+            return undef unless @objects;
+
+            my $is_truncated
+                = scalar $xpc->findvalue(
+                '/s3:ListBucketResult/s3:IsTruncated') eq 'true'
+                ? 1
+                : 0;
+            $end = 1 unless $is_truncated;
+
+            $marker = $xpc->findvalue('/s3:ListBucketResult/s3:NextMarker')
+                || $objects[-1]->key;
+
+            return \@objects;
+        }
+    );
+}
+
 sub list_uploads {
     my ( $self, $conf ) = @_;
     $conf ||= {};

--- a/lib/Net/Amazon/S3/Client/Object.pm
+++ b/lib/Net/Amazon/S3/Client/Object.pm
@@ -661,6 +661,14 @@ C<user_metadata>.
   The etag and part_numbers parameters are ordered lists specifying the part
   numbers and ETags for each individual part of the multipart upload.
 
+=head2 abort_multipart_upload
+
+  #abort pending upload to free storage space
+  #you should check for such stale uploads to avoid unnecessary cost frequently
+  $object->abort_multipart_upload(
+    upload_id => $upload_id
+  );
+
 =head2 user_metadata
 
   my $object = $bucket->object(key => $key);

--- a/lib/Net/Amazon/S3/Client/Object.pm
+++ b/lib/Net/Amazon/S3/Client/Object.pm
@@ -169,7 +169,7 @@ sub get_filename {
     my $etag = $self->etag || $self->_etag($http_response);
     unless ($self->_is_multipart_etag($etag)) {
         my $md5_hex = file_md5_hex($filename);
-        confess 'Corrupted download' if $etag ne $md5_hex;
+        confess "Corrupted download: $filename ($etag/$md5_hex)" if $etag ne $md5_hex;
     }
 }
 

--- a/lib/Net/Amazon/S3/Client/Object.pm
+++ b/lib/Net/Amazon/S3/Client/Object.pm
@@ -111,6 +111,20 @@ sub _get {
     return $http_response;
 }
 
+sub head {
+    my $self = shift;
+    my $http_request = Net::Amazon::S3::Request::GetObject->new(
+        s3     => $self->client->s3,
+        bucket => $self->bucket->name,
+        key    => $self->key,
+        method => 'HEAD',
+    )->http_request;
+
+    my $http_response = $self->client->_send_request($http_request);
+    $self->_load_user_metadata($http_response);
+    return;
+}
+
 sub get {
     my $self = shift;
     return $self->_get->content;
@@ -426,8 +440,12 @@ no strict 'vars'
   my $object = $bucket->object( key => 'this is the key' );
   $object->put('this is the value');
 
-  # to get the vaue of an object
+  # to get the value of an object
   my $value = $object->get;
+
+  # to fetch just the user metadata of an object
+  $object->head;
+  my $user_metadata = $object->user_metadata;
 
   # to see if an object exists
   if ($object->exists) { ... }
@@ -520,6 +538,13 @@ This module represents objects in buckets.
   # download the value of the object into a file
   my $object = $bucket->object( key => 'images/my_hat.jpg' );
   $object->get_filename('hat_backup.jpg');
+
+=head2 head
+
+  # download just the metadata (including user metadata) without the actual data
+  my $object = $bucket->object( key => 'images/my_hat.jpg' );
+  $object->head;
+  my $user_metadata = $object->user_metadata;
 
 =head2 last_modified, last_modified_raw
 

--- a/lib/Net/Amazon/S3/Client/Object.pm
+++ b/lib/Net/Amazon/S3/Client/Object.pm
@@ -422,6 +422,16 @@ sub _is_multipart_etag {
     return 1 if($etag =~ /\-\d+$/);
 }
 
+sub versions {
+    my ( $self ) = @_;
+    my @list;
+    my $stream = $self->bucket->versions( { prefix => $self->key } );
+    until ($stream->is_done) {
+        push @list, $stream->items;
+    }
+    return @list;
+}
+
 1;
 
 __END__

--- a/lib/Net/Amazon/S3/Client/Object.pm
+++ b/lib/Net/Amazon/S3/Client/Object.pm
@@ -269,11 +269,15 @@ sub delete {
 
 sub initiate_multipart_upload {
     my $self = shift;
+    my $conf;
+    $conf->{"x-amz-meta-\L$_"} = $self->user_metadata->{$_}
+        for keys %{ $self->user_metadata };
     my $http_request = Net::Amazon::S3::Request::InitiateMultipartUpload->new(
         s3     => $self->client->s3,
         bucket => $self->bucket->name,
         key    => $self->key,
         encryption => $self->encryption,
+        headers => $conf,
     )->http_request;
     my $xpc = $self->client->_send_request_xpc($http_request);
     my $upload_id = $xpc->findvalue('//s3:UploadId');

--- a/lib/Net/Amazon/S3/Client/Object.pm
+++ b/lib/Net/Amazon/S3/Client/Object.pm
@@ -24,8 +24,8 @@ has 'client' =>
 has 'bucket' =>
     ( is => 'ro', isa => 'Net::Amazon::S3::Client::Bucket', required => 1 );
 has 'key'  => ( is => 'ro', isa => 'Str',  required => 1 );
-has 'etag' => ( is => 'ro', isa => 'Etag', required => 0 );
-has 'size' => ( is => 'ro', isa => 'Int',  required => 0 );
+has 'etag' => ( is => 'rw', isa => 'Etag', required => 0 );
+has 'size' => ( is => 'rw', isa => 'Int',  required => 0 );
 has 'last_modified' =>
     ( is => 'ro', isa => DateTime, coerce => 1, required => 0, default => sub { shift->last_modified_raw }, lazy => 1 );
 has 'last_modified_raw' =>
@@ -238,6 +238,8 @@ sub _put {
         if $http_response->code != 200;
 
     my $etag = $self->_etag($http_response);
+    $self->etag( $etag );
+    $self->size( $size );
 
     confess "Corrupted upload got $etag expected $md5_hex" if $etag ne $md5_hex;
 }

--- a/lib/Net/Amazon/S3/HTTPRequest.pm
+++ b/lib/Net/Amazon/S3/HTTPRequest.pm
@@ -8,7 +8,6 @@ use Moose::Util::TypeConstraints;
 use URI::Escape qw( uri_escape_utf8 );
 use URI::QueryParam;
 use URI;
-use VM::EC2::Security::CredentialCache;
 
 # ABSTRACT: Create a signed HTTP::Request
 
@@ -99,6 +98,7 @@ sub _add_auth_header {
     my ( $self, $headers, $method, $path ) = @_;
 
     if ($self->s3->use_iam_role) {
+        require VM::EC2::Security::CredentialCache;
         my $creds = VM::EC2::Security::CredentialCache->get();
         defined($creds) || die("Unable to retrieve IAM role credentials");
         $self->s3->aws_access_key_id($creds->accessKeyId);
@@ -169,7 +169,7 @@ sub _canonical_string {
     $buf .= "/$1";
 
     # ...unless there any parameters we're interested in...
-    if ( $path =~ /[&?](acl|torrent|location|uploads|delete)($|=|&)/ ) {
+    if ( $path =~ /[&?](acl|torrent|location|uploads|delete|versions)($|=|&)/ ) {
         $buf .= "?$1";
     } elsif ( my %query_params = URI->new($path)->query_form ){
         #see if the remaining parsed query string provides us with any query string or upload id

--- a/lib/Net/Amazon/S3/Request/ListMultipartUploads.pm
+++ b/lib/Net/Amazon/S3/Request/ListMultipartUploads.pm
@@ -1,0 +1,48 @@
+package Net::Amazon::S3::Request::ListMultipartUploads;
+
+use Moose 0.85;
+use MooseX::StrictConstructor 0.16;
+use URI::Escape qw(uri_escape_utf8);
+extends 'Net::Amazon::S3::Request';
+
+# ABSTRACT: List the parts in a pending multipart upload.
+
+has 'bucket'    => ( is => 'ro', isa => 'BucketName', required => 1 );
+has 'prefix'    => ( is => 'ro', isa => 'Maybe[Str]', required => 0 );
+has 'delimiter' => ( is => 'ro', isa => 'Maybe[Str]', required => 0 );
+has 'max_keys'  => ( is => 'ro', isa => 'Maybe[Int]', required => 0, default => 1000 );
+has 'marker'    => ( is => 'ro', isa => 'Maybe[Str]', required => 0 );
+
+__PACKAGE__->meta->make_immutable;
+
+sub http_request {
+    my $self    = shift;
+
+    my $path = $self->bucket . "/?uploads";
+    my @post;
+    foreach my $method ( qw(prefix delimiter max_keys marker) ) {
+        my $value = $self->$method;
+        next unless $value;
+        my $key = $method;
+        $key = 'max-keys' if $method eq 'max_keys';
+        $key = 'key-marker' if $method eq 'marker';
+        push @post, $key . "=" . $self->_urlencode($value);
+    }
+    if (@post) {
+        $path .= '&' . join( '&', @post );
+    }
+
+
+    return Net::Amazon::S3::HTTPRequest->new(
+        s3      => $self->s3,
+        method  => 'GET',
+        path    => $path,
+    )->http_request;
+}
+
+sub _urlencode {
+    my ( $self, $unencoded ) = @_;
+    return uri_escape_utf8( $unencoded, '^A-Za-z0-9_-' );
+}
+
+1;

--- a/lib/Net/Amazon/S3/Request/ListVersions.pm
+++ b/lib/Net/Amazon/S3/Request/ListVersions.pm
@@ -1,0 +1,72 @@
+package Net::Amazon::S3::Request::ListVersions;
+
+use Moose 0.85;
+use MooseX::StrictConstructor 0.16;
+use URI::Escape qw(uri_escape_utf8);
+extends 'Net::Amazon::S3::Request';
+
+# ABSTRACT: An internal class to list a bucket
+
+has 'bucket'    => ( is => 'ro', isa => 'BucketName', required => 1 );
+has 'prefix'    => ( is => 'ro', isa => 'Maybe[Str]', required => 0 );
+has 'delimiter' => ( is => 'ro', isa => 'Maybe[Str]', required => 0 );
+has 'max_keys' =>
+    ( is => 'ro', isa => 'Maybe[Int]', required => 0, default => 1000 );
+has 'marker' => ( is => 'ro', isa => 'Maybe[Str]', required => 0 );
+
+__PACKAGE__->meta->make_immutable;
+
+sub http_request {
+    my $self = shift;
+
+    my $path = $self->bucket . "/?versions";
+
+    my @post;
+    foreach my $method ( qw(prefix delimiter max_keys marker) ) {
+        my $value = $self->$method;
+        next unless $value;
+        my $key = $method;
+        $key = 'max-keys' if $method eq 'max_keys';
+        push @post, $key . "=" . $self->_urlencode($value);
+    }
+    $path .= join( '&', '', @post ) if @post;
+
+    return Net::Amazon::S3::HTTPRequest->new(
+        s3     => $self->s3,
+        method => 'GET',
+        path   => $path,
+    )->http_request;
+}
+
+sub _urlencode {
+    my ( $self, $unencoded ) = @_;
+    return uri_escape_utf8( $unencoded, '^A-Za-z0-9_-' );
+}
+
+1;
+
+__END__
+
+=for test_synopsis
+no strict 'vars'
+
+=head1 SYNOPSIS
+
+  my $http_request = Net::Amazon::S3::Request::ListVersions->new(
+    s3        => $s3,
+    bucket    => $bucket,
+    delimiter => $delimiter,
+    max_keys  => $max_keys,
+    marker    => $marker,
+  )->http_request;
+
+=head1 DESCRIPTION
+
+This module lists versions of all selected objects in a bucket.
+
+=head1 METHODS
+
+=head2 http_request
+
+This method returns a HTTP::Request object.
+


### PR DESCRIPTION
Added support for HEAD requests to Client (this differs a bit from exists in that is also makes the user metadata available).

Also, the support for handling stale multipart uploads was incomplete, thus added request/methods to list such uploads and methods to abort/delete them.

Please let me know should you have any questions.

BTW: Should Client offer all functions of the lower-level S3? What are the design goals for Client?
