### PR TITLE
Support for response header override in signed urls

### DIFF
--- a/lib/Net/Amazon/S3/Client/Object.pm
+++ b/lib/Net/Amazon/S3/Client/Object.pm
@@ -335,13 +335,13 @@ sub uri {
 }
 
 sub query_string_authentication_uri {
-    my $self = shift;
+    my ($self, $query_form) = @_;
     return Net::Amazon::S3::Request::GetObject->new(
         s3     => $self->client->s3,
         bucket => $self->bucket->name,
         key    => $self->key,
         method => 'GET',
-    )->query_string_authentication_uri( $self->expires->epoch );
+    )->query_string_authentication_uri( $self->expires->epoch, $query_form );
 }
 
 sub _content_sub {
@@ -585,12 +585,14 @@ C<user_metadata>.
 
 =head2 query_string_authentication_uri
 
-  # use query string authentication
+  # use query string authentication, forcing download with custom filename
   my $object = $bucket->object(
     key          => 'images/my_hat.jpg',
     expires      => '2009-03-01',
   );
-  my $uri = $object->query_string_authentication_uri();
+  my $uri = $object->query_string_authentication_uri({
+    'response-content-disposition' => 'attachment; filename=abc.doc',
+  });
 
 =head2 size
 
@@ -648,4 +650,3 @@ To upload an object with user metadata, set C<user_metadata> at construction
 time to a hashref, with no C<x-amz-meta-> prefixes on the key names.  When
 downloading an object, the C<get>, C<get_decoded> and C<get_filename>
 ethods set the contents of C<user_metadata> to the same format.
-

--- a/lib/Net/Amazon/S3/Request/GetObject.pm
+++ b/lib/Net/Amazon/S3/Request/GetObject.pm
@@ -23,12 +23,15 @@ sub http_request {
 }
 
 sub query_string_authentication_uri {
-    my ( $self, $expires ) = @_;
+    my ( $self, $expires, $query_form ) = @_;
+
+    my $uri = URI->new( $self->_uri( $self->key ) );
+    $uri->query_form( %$query_form ) if $query_form;
 
     return Net::Amazon::S3::HTTPRequest->new(
         s3     => $self->s3,
         method => $self->method,
-        path   => $self->_uri( $self->key ),
+        path   => $uri->as_string,
     )->query_string_authentication_uri($expires);
 }
 
@@ -61,4 +64,3 @@ This method returns a HTTP::Request object.
 =head2 query_string_authentication_uri
 
 This method returns query string authentication URI.
-

--- a/t/02client.t
+++ b/t/02client.t
@@ -143,6 +143,22 @@ is( get( $object->query_string_authentication_uri() ),
     'newly created object can be fetch by authentication uri'
 );
 
+
+my $signed_url = $object->query_string_authentication_uri({
+    'response-content-disposition' => 'attachment; filename=abc.doc'
+});
+
+like(
+    $signed_url,
+    qr/response-content-disposition/,
+    'cuttom response headers included in the signed uri'
+);
+
+is( get( $signed_url ),
+    'this is the value',
+    'newly created object can be fetch by authentication uri with custom headers'
+);
+
 $object->delete;
 
 # upload a public object


### PR DESCRIPTION
This allows one to generate signed urls that return content with specific headers. This is useful if you don't remember to set content_disposition when uploading files, or later you decide to use a different filename. Also, browser can be forced to show the file instead of downloading by setting the disposition to 'inline'.

```perl
my $object = $bucket->object(
  key          => 'images/my_hat.jpg',
  expires      => '2009-03-01',
);
my $uri = $object->query_string_authentication_uri({
  'response-content-disposition' => 'attachment; filename=abc.doc',
});
# $uri = http://s3.amazonaws.com/bucket/images/my_hat.jpg?response-content-disposition=attachment%3B+filename%3Dabc.doc&AWSAccessKeyId=...
```

```
$ curl -v http://s3.amazonaws.com/bucket/images/my_hat.jpg?response-content-disposition=attachment%3B+filename%3Dabc.doc&AWSAccessKeyId=...
>  ...
>  Content-Disposition: attachment; filename=abc.doc
>  ...
```
