### PR TITLE
Updated the pod, to reflected the need for LWP::Protocol::https, when…

### DIFF
--- a/lib/Net/Amazon/S3.pm
+++ b/lib/Net/Amazon/S3.pm
@@ -196,6 +196,8 @@ with a true value.
 Set this to C<1> if you want to use SSL-encrypted connections when talking
 to S3. Defaults to C<0>.
 
+To use SSL-encrypted connections, LWP::Protocol::https is required.
+
 =item timeout
 
 How many seconds should your script wait before bailing on a request to S3? Defaults


### PR DESCRIPTION
… using secure connections

When using secure connections to S3,  LWP::Protocol::https is used under the hood.

This is not essential to the modules running as it is only specific to HTTPS connection, however it could catch some people off guard, when they expect it just to work.

I would have put this in the dist.ini, however is failing a non-critical test, however you may want to do that once the module has passing tests.
