### PR TITLE
Sanity object uris to avoid invalid signature (issue #28)

### DIFF
--- a/lib/Net/Amazon/S3/Request.pm
+++ b/lib/Net/Amazon/S3/Request.pm
@@ -91,9 +91,15 @@ sub _uri {
     my ( $self, $key ) = @_;
     my $bucket = $self->bucket->bucket;
 
-    return (defined($key))
+    my $uri = (defined($key))
         ? $bucket . "/" . (join '/', map {$self->s3->_urlencode($_)} split /\//, $key)
         : $bucket . "/";
+
+    # Although Amazon's Signature 4 test suite explicitely handles // it appears
+    # it's inconsistent with their implementation so removing it here
+    $uri =~ s{//+}{/}g;
+
+    return $uri;
 }
 
 sub _build_signed_request {


### PR DESCRIPTION
Signature 4 documentation and test suite says that sequence of multiple
slashes should reduced to one (get-slashes test).

Although V4Implementation follows that performing such request causes
invalid signature error.