### PR TITLE
Bugfixes

### DIFF
--- a/lib/Net/Amazon/S3.pm
+++ b/lib/Net/Amazon/S3.pm
@@ -145,7 +145,7 @@ my $AMAZON_S3_HOST = 's3.amazonaws.com';
 has 'use_iam_role' => ( is => 'ro', isa => 'Bool', required => 0, default => 0);
 has 'aws_access_key_id'     => ( is => 'rw', isa => 'Str', required => 0 );
 has 'aws_secret_access_key' => ( is => 'rw', isa => 'Str', required => 0 );
-has 'secure' => ( is => 'ro', isa => 'Bool', required => 0, default => 0 );
+has 'secure' => ( is => 'ro', isa => 'Bool', required => 0, default => 1 );
 has 'timeout' => ( is => 'ro', isa => 'Num',  required => 0, default => 30 );
 has 'retry'   => ( is => 'ro', isa => 'Bool', required => 0, default => 0 );
 has 'host'    => ( is => 'ro', isa => 'Str',  required => 0, default => $AMAZON_S3_HOST );
@@ -215,8 +215,8 @@ with a true value.
 
 =item secure
 
-Set this to C<1> if you want to use SSL-encrypted connections when talking
-to S3. Defaults to C<0>.
+Set this to C<0> if you don't want to use SSL-encrypted connections when talking
+to S3. Defaults to C<1>.
 
 To use SSL-encrypted connections, LWP::Protocol::https is required.
 

--- a/lib/Net/Amazon/S3.pm
+++ b/lib/Net/Amazon/S3.pm
@@ -140,13 +140,15 @@ use URI::Escape qw(uri_escape_utf8);
 use XML::LibXML;
 use XML::LibXML::XPathContext;
 
+my $AMAZON_S3_HOST = 's3.amazonaws.com';
+
 has 'use_iam_role' => ( is => 'ro', isa => 'Bool', required => 0, default => 0);
 has 'aws_access_key_id'     => ( is => 'rw', isa => 'Str', required => 0 );
 has 'aws_secret_access_key' => ( is => 'rw', isa => 'Str', required => 0 );
 has 'secure' => ( is => 'ro', isa => 'Bool', required => 0, default => 0 );
 has 'timeout' => ( is => 'ro', isa => 'Num',  required => 0, default => 30 );
 has 'retry'   => ( is => 'ro', isa => 'Bool', required => 0, default => 0 );
-has 'host'    => ( is => 'ro', isa => 'Str',  required => 0, default => 's3.amazonaws.com' );
+has 'host'    => ( is => 'ro', isa => 'Str',  required => 0, default => $AMAZON_S3_HOST );
 has 'use_virtual_host' => (
     is => 'ro',
     isa => 'Bool',
@@ -163,7 +165,12 @@ has authorization_method => (
     is => 'ro',
     isa => 'Str',
     required => 0,
-    default => 'Net::Amazon::S3::Signature::V4',
+    lazy => 1,
+    default => sub {
+        $_[0]->host eq $AMAZON_S3_HOST
+            ? 'Net::Amazon::S3::Signature::V4'
+            : 'Net::Amazon::S3::Signature::V2'
+    },
 );
 
 __PACKAGE__->meta->make_immutable;
@@ -229,14 +236,20 @@ as recommended by Amazon. Defaults to off.
 The S3 host endpoint to use. Defaults to 's3.amazonaws.com'. This allows
 you to connect to any S3-compatible host.
 
-=back
-
 =item use_virtual_host
 
 Use the virtual host method ('bucketname.s3.amazonaws.com') instead of specifying the
 bucket at the first part of the path. This is particularily useful if you want to access
 buckets not located in the US-Standard region (such as EU, Asia Pacific or South America).
 See L<http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html> for the pros and cons.
+
+=item authorization_method
+
+Authorization implementation package name.
+
+This library provides L<< Net::Amazon::S3::Signature::V2 >> and L<< Net::Amazon::S3::Signature::V4 >>
+
+Default is Signature 4 if host is C<< s3.amazonaws.com >>, Signature 2 otherwise
 
 =back
 

--- a/lib/Net/Amazon/S3/Client.pm
+++ b/lib/Net/Amazon/S3/Client.pm
@@ -9,8 +9,6 @@ use Moose::Util::TypeConstraints;
 
 type 'Etag' => where { $_ =~ /^[a-z0-9]{32}(?:-\d+)?$/ };
 
-type 'OwnerId' => where { $_ =~ /^[a-z0-9]{64}$/ };
-
 has 's3' => ( is => 'ro', isa => 'Net::Amazon::S3', required => 1 );
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/Net/Amazon/S3/Client/Bucket.pm
+++ b/lib/Net/Amazon/S3/Client/Bucket.pm
@@ -12,7 +12,7 @@ has 'client' =>
 has 'name' => ( is => 'ro', isa => 'Str', required => 1 );
 has 'creation_date' =>
     ( is => 'ro', isa => DateTime, coerce => 1, required => 0 );
-has 'owner_id'           => ( is => 'ro', isa => 'OwnerId', required => 0 );
+has 'owner_id'           => ( is => 'ro', isa => 'Str', required => 0 );
 has 'owner_display_name' => ( is => 'ro', isa => 'Str',     required => 0 );
 has 'region' => (
     is => 'ro',


### PR DESCRIPTION
- Use Signature 4 by default only for amazonaws host (issue #29) 
-  Relaxing constraint on owner id, accepting any string (issue #18)
- Enable secure by default (issue #23) 