### PR TITLE
Put back credential cache code lost in Signature 4 patch

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -18,6 +18,8 @@ repository.type   = git
 
 [Prereqs]
 LWP = 6.03
+[Prereqs / RuntimeRecommends]
+VM::EC2::Security::CredentialCache = 0
 [AutoPrereqs]
 [CPANFile]
 

--- a/lib/Net/Amazon/S3.pm
+++ b/lib/Net/Amazon/S3.pm
@@ -173,6 +173,19 @@ has authorization_method => (
     },
 );
 
+sub BUILD {
+    my ($self) = @_;
+
+    if ($self->use_iam_role) {
+        eval "require VM::EC2::Security::CredentialCache" or die $@;
+        my $creds = VM::EC2::Security::CredentialCache->get();
+        defined($creds) || die("Unable to retrieve IAM role credentials");
+        $self->aws_access_key_id($creds->accessKeyId);
+        $self->aws_secret_access_key($creds->secretAccessKey);
+        $self->aws_session_token($creds->sessionToken);
+    }
+}
+
 __PACKAGE__->meta->make_immutable;
 
 my $KEEP_ALIVE_CACHESIZE = 10;

--- a/lib/Net/Amazon/S3/HTTPRequest.pm
+++ b/lib/Net/Amazon/S3/HTTPRequest.pm
@@ -8,7 +8,6 @@ use Moose::Util::TypeConstraints;
 use URI::Escape qw( uri_escape_utf8 );
 use URI::QueryParam;
 use URI;
-use VM::EC2::Security::CredentialCache;
 
 use Net::Amazon::S3::Signature::V2;
 

--- a/lib/Net/Amazon/S3/Signature/V2.pm
+++ b/lib/Net/Amazon/S3/Signature/V2.pm
@@ -10,7 +10,6 @@ use HTTP::Date qw[ time2str ];
 use MIME::Base64 qw( encode_base64 );
 use URI::QueryParam;
 use URI;
-use VM::EC2::Security::CredentialCache;
 
 use namespace::clean;
 


### PR DESCRIPTION
and making its dependency only optional (issue #12)