### PR TITLE
Support standard_ia and onezone_ia storage classes

### DIFF
--- a/lib/Net/Amazon/S3/Client/Object.pm
+++ b/lib/Net/Amazon/S3/Client/Object.pm
@@ -17,7 +17,7 @@ enum 'AclShort' =>
     [ qw(private public-read public-read-write authenticated-read) ];
 
 enum 'StorageClass' =>
-    [ qw(standard reduced_redundancy) ];
+    [ qw(standard reduced_redundancy standard_ia onezone_ia) ];
 
 has 'client' =>
     ( is => 'ro', isa => 'Net::Amazon::S3::Client', required => 1 );
@@ -554,7 +554,8 @@ You may also set Content-Encoding using C<content_encoding>, and
 Content-Disposition using C<content_disposition>.
 
 You may specify the S3 storage class by setting C<storage_class> to either
-C<standard> or C<reduced_redundancy>; the default is C<standard>.
+C<standard>, C<reduced_redundancy>, C<standard_ia>, or C<onezone_ia>;
+the default is C<standard>.
 
 =head2 put_filename
 
@@ -578,7 +579,8 @@ You may also set Content-Encoding using C<content_encoding>, and
 Content-Disposition using C<content_disposition>.
 
 You may specify the S3 storage class by setting C<storage_class> to either
-C<standard> or C<reduced_redundancy>; the default is C<standard>.
+C<standard>, C<reduced_redundancy>, C<standard_ia>, or C<onezone_ia>;
+the default is C<standard>.
 
 User metadata may be set by providing a non-empty hashref as
 C<user_metadata>.


### PR DESCRIPTION
Patched the StorageClass enum (and documentation) to allow storage in the STANDARD-IA and ONEZONE-IA classes.