### PR TITLE
consistently provide Pod::Weaver abstracts

### DIFF
--- a/lib/Net/Amazon/S3/Request/Bucket.pm
+++ b/lib/Net/Amazon/S3/Request/Bucket.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Bucket;
+# ABSTRACT: Base class for all S3 Bucket operations
 
 use Moose 0.85;
 use MooseX::StrictConstructor 0.16;
@@ -16,14 +17,3 @@ __PACKAGE__->meta->make_immutable;
 
 1;
 
-__END__
-
-=head1 NAME
-
-Net::Amazon::S3::Request::Bucket
-
-=head1 DESCRIPTION
-
-Base class for all S3 Bucket operations
-
-=cut

--- a/lib/Net/Amazon/S3/Request/Object.pm
+++ b/lib/Net/Amazon/S3/Request/Object.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Object;
+# ABSTRACT: Base class for all S3 Object operations
 
 use Moose 0.85;
 use MooseX::StrictConstructor 0.16;
@@ -20,14 +21,3 @@ __PACKAGE__->meta->make_immutable;
 
 1;
 
-__END__
-
-=head1 NAME
-
-Net::Amazon::S3::Request::Object
-
-=head1 DESCRIPTION
-
-Base class for all S3 Object operations
-
-=cut

--- a/lib/Net/Amazon/S3/Request/Role/HTTP/Header.pm
+++ b/lib/Net/Amazon/S3/Request/Role/HTTP/Header.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::HTTP::Header;
+# ABSTRACT: HTTP Header Role
 
 use MooseX::Role::Parameterized;
 

--- a/lib/Net/Amazon/S3/Request/Role/HTTP/Header/Acl_short.pm
+++ b/lib/Net/Amazon/S3/Request/Role/HTTP/Header/Acl_short.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::HTTP::Header::Acl_short;
+# ABSTRACT: x-amz-acl header role
 
 use Moose::Role;
 

--- a/lib/Net/Amazon/S3/Request/Role/HTTP/Header/Content_length.pm
+++ b/lib/Net/Amazon/S3/Request/Role/HTTP/Header/Content_length.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::HTTP::Header::Content_length;
+# ABSTRACT: Content-Lenghth header role
 
 use Moose::Role;
 use Digest::MD5 qw[];

--- a/lib/Net/Amazon/S3/Request/Role/HTTP/Header/Content_md5.pm
+++ b/lib/Net/Amazon/S3/Request/Role/HTTP/Header/Content_md5.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::HTTP::Header::Content_md5;
+# ABSTRACT: Content-MD5 header role
 
 use Moose::Role;
 use Digest::MD5 qw[];

--- a/lib/Net/Amazon/S3/Request/Role/HTTP/Header/Content_type.pm
+++ b/lib/Net/Amazon/S3/Request/Role/HTTP/Header/Content_type.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::HTTP::Header::Content_type;
+# ABSTRACT: Content-Type header role
 
 use MooseX::Role::Parameterized;
 

--- a/lib/Net/Amazon/S3/Request/Role/HTTP/Header/Copy_source.pm
+++ b/lib/Net/Amazon/S3/Request/Role/HTTP/Header/Copy_source.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::HTTP::Header::Copy_source;
+# ABSTRACT: x-amz-copy-source header role
 
 use Moose::Role;
 

--- a/lib/Net/Amazon/S3/Request/Role/HTTP/Header/Encryption.pm
+++ b/lib/Net/Amazon/S3/Request/Role/HTTP/Header/Encryption.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::HTTP::Header::Encryption;
+# ABSTRACT: x-amz-server-side-encryption header role
 
 use Moose::Role;
 

--- a/lib/Net/Amazon/S3/Request/Role/HTTP/Method.pm
+++ b/lib/Net/Amazon/S3/Request/Role/HTTP/Method.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::HTTP::Method;
+# ABSTRACT: HTTP method role
 
 use MooseX::Role::Parameterized;
 

--- a/lib/Net/Amazon/S3/Request/Role/HTTP/Method/DELETE.pm
+++ b/lib/Net/Amazon/S3/Request/Role/HTTP/Method/DELETE.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::HTTP::Method::DELETE;
+# ABSTRACT: HTTP DELETE method role
 
 use Moose::Role;
 

--- a/lib/Net/Amazon/S3/Request/Role/HTTP/Method/GET.pm
+++ b/lib/Net/Amazon/S3/Request/Role/HTTP/Method/GET.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::HTTP::Method::GET;
+# ABSTRACT: HTTP GET method role
 
 use Moose::Role;
 

--- a/lib/Net/Amazon/S3/Request/Role/HTTP/Method/POST.pm
+++ b/lib/Net/Amazon/S3/Request/Role/HTTP/Method/POST.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::HTTP::Method::POST;
+# ABSTRACT: HTTP POST method role
 
 use Moose::Role;
 

--- a/lib/Net/Amazon/S3/Request/Role/HTTP/Method/PUT.pm
+++ b/lib/Net/Amazon/S3/Request/Role/HTTP/Method/PUT.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::HTTP::Method::PUT;
+# ABSTRACT: HTTP PUT method role
 
 use Moose::Role;
 

--- a/lib/Net/Amazon/S3/Request/Role/Query/Action.pm
+++ b/lib/Net/Amazon/S3/Request/Role/Query/Action.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::Query::Action;
+# ABSTRACT: query action role
 
 use MooseX::Role::Parameterized;
 

--- a/lib/Net/Amazon/S3/Request/Role/Query/Action/Acl.pm
+++ b/lib/Net/Amazon/S3/Request/Role/Query/Action/Acl.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::Query::Action::Acl;
+# ABSTRACT: acl query action role
 
 use Moose::Role;
 

--- a/lib/Net/Amazon/S3/Request/Role/Query/Action/Delete.pm
+++ b/lib/Net/Amazon/S3/Request/Role/Query/Action/Delete.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::Query::Action::Delete;
+# ABSTRACT: delete query action role
 
 use Moose::Role;
 

--- a/lib/Net/Amazon/S3/Request/Role/Query/Action/Location.pm
+++ b/lib/Net/Amazon/S3/Request/Role/Query/Action/Location.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::Query::Action::Location;
+# ABSTRACT: location query action role
 
 use Moose::Role;
 

--- a/lib/Net/Amazon/S3/Request/Role/Query/Action/Uploads.pm
+++ b/lib/Net/Amazon/S3/Request/Role/Query/Action/Uploads.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::Query::Action::Uploads;
+# ABSTRACT: uploads query action role
 
 use Moose::Role;
 

--- a/lib/Net/Amazon/S3/Request/Role/Query/Param.pm
+++ b/lib/Net/Amazon/S3/Request/Role/Query/Param.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::Query::Param;
+# ABSTRACT: request query params role
 
 use MooseX::Role::Parameterized;
 

--- a/lib/Net/Amazon/S3/Request/Role/Query/Param/Delimiter.pm
+++ b/lib/Net/Amazon/S3/Request/Role/Query/Param/Delimiter.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::Query::Param::Delimiter;
+# ABSTRACT: delimiter query param role
 
 use Moose::Role;
 

--- a/lib/Net/Amazon/S3/Request/Role/Query/Param/Marker.pm
+++ b/lib/Net/Amazon/S3/Request/Role/Query/Param/Marker.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::Query::Param::Marker;
+# ABSTRACT: marker query param role
 
 use Moose::Role;
 

--- a/lib/Net/Amazon/S3/Request/Role/Query/Param/Max_keys.pm
+++ b/lib/Net/Amazon/S3/Request/Role/Query/Param/Max_keys.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::Query::Param::Max_keys;
+# ABSTRACT: max-keys query param role
 
 use Moose::Role;
 

--- a/lib/Net/Amazon/S3/Request/Role/Query/Param/Part_number.pm
+++ b/lib/Net/Amazon/S3/Request/Role/Query/Param/Part_number.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::Query::Param::Part_number;
+# ABSTRACT: partNumber query param role
 
 use Moose::Role;
 

--- a/lib/Net/Amazon/S3/Request/Role/Query/Param/Prefix.pm
+++ b/lib/Net/Amazon/S3/Request/Role/Query/Param/Prefix.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::Query::Param::Prefix;
+# ABSTRACT: prefix query param role
 
 use Moose::Role;
 

--- a/lib/Net/Amazon/S3/Request/Role/Query/Param/Upload_id.pm
+++ b/lib/Net/Amazon/S3/Request/Role/Query/Param/Upload_id.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Role::Query::Param::Upload_id;
+# ABSTRACT: upload_id query param role
 
 use Moose::Role;
 

--- a/lib/Net/Amazon/S3/Request/Service.pm
+++ b/lib/Net/Amazon/S3/Request/Service.pm
@@ -1,4 +1,5 @@
 package Net::Amazon::S3::Request::Service;
+# ABSTRACT: Base class for all S3 Service operations
 
 use Moose 0.85;
 use MooseX::StrictConstructor 0.16;
@@ -8,14 +9,3 @@ __PACKAGE__->meta->make_immutable;
 
 1;
 
-__END__
-
-=head1 NAME
-
-Net::Amazon::S3::Request::Service
-
-=head1 DESCRIPTION
-
-Base class for all S3 Service operations
-
-=cut

--- a/lib/Net/Amazon/S3/Role/Bucket.pm
+++ b/lib/Net/Amazon/S3/Role/Bucket.pm
@@ -1,8 +1,5 @@
-
-use strict;
-use warnings;
-
 package Net::Amazon::S3::Role::Bucket;
+# ABSTRACT: Bucket role
 
 use Moose::Role;
 use Scalar::Util;

--- a/lib/Net/Amazon/S3/Signature.pm
+++ b/lib/Net/Amazon/S3/Signature.pm
@@ -1,8 +1,5 @@
-
-use strict;
-use warnings;
-
 package Net::Amazon::S3::Signature;
+# ABSTRACT: S3 Signature implementation base class
 
 use Moose;
 
@@ -27,25 +24,17 @@ sub sign_uri {
 
 __END__
 
-=head1 NAME
-
-Net::Amazon::S3::Signature - S3 Signature implementation base class
-
-=head1 METHODS
-
-=over
-
-=item new
+=method new
 
 Signature class should accept HTTPRequest instance and determine every
 required parameter via this instance
 
-=item sign_request( $request )
+=method sign_request( $request )
 
 Signature class should return authenticated request based on given parameter.
 Parameter can be modified.
 
-=item sign_uri( $request, $expires_at? )
+=method sign_uri( $request, $expires_at? )
 
 Signature class should return authenticated uri based on given request.
 
@@ -55,5 +44,3 @@ Default and maximal allowed value may depend on signature version.
 Default request date is current time.
 Signature class should accept provided C<< X-Amz-Date >> header instead (if signing request)
 or query parameter (if signing uri)
-
-=back

--- a/lib/Net/Amazon/S3/Signature/V2.pm
+++ b/lib/Net/Amazon/S3/Signature/V2.pm
@@ -1,8 +1,5 @@
-
-use strict;
-use warnings;
-
 package Net::Amazon::S3::Signature::V2;
+# ABSTRACT: V2 signatures
 
 use Moose;
 use URI::Escape qw( uri_escape_utf8 );

--- a/lib/Net/Amazon/S3/Signature/V4.pm
+++ b/lib/Net/Amazon/S3/Signature/V4.pm
@@ -1,8 +1,5 @@
-
-use strict;
-use warnings;
-
 package Net::Amazon::S3::Signature::V4;
+# ABSTRACT: V4 signatures
 
 use Moose;
 

--- a/lib/Net/Amazon/S3/Signature/V4Implementation.pm
+++ b/lib/Net/Amazon/S3/Signature/V4Implementation.pm
@@ -1,6 +1,6 @@
 #package Net::Amazon::Signature::V4;
 package Net::Amazon::S3::Signature::V4Implementation;
-
+# ABSTRACT: Implements the Amazon Web Services signature version 4, AWS4-HMAC-SHA256 (copy of Net::Amazon::Signature::V4)
 
 
 use strict;
@@ -23,10 +23,6 @@ our $X_AMZ_DATE           = 'X-Amz-Date';
 our $X_AMZ_EXPIRES        = 'X-Amz-Expires';
 our $X_AMZ_SIGNEDHEADERS  = 'X-Amz-SignedHeaders';
 our $X_AMZ_SIGNATURE      = 'X-Amz-Signature';
-
-=head1 NAME
-
-Net::Amazon::Signature::V4 - Implements the Amazon Web Services signature version 4, AWS4-HMAC-SHA256
 
 =head1 VERSION
 

--- a/lib/Shared/Examples/Net/Amazon/S3.pm
+++ b/lib/Shared/Examples/Net/Amazon/S3.pm
@@ -1,4 +1,5 @@
 package Shared::Examples::Net::Amazon::S3;
+# ABSTRACT: used for testing and as example
 
 use strict;
 use warnings;

--- a/lib/Shared/Examples/Net/Amazon/S3/ACL.pm
+++ b/lib/Shared/Examples/Net/Amazon/S3/ACL.pm
@@ -1,4 +1,5 @@
 package Shared::Examples::Net::Amazon::S3::ACL;
+# ABSTRACT: used for testing and as example
 
 use strict;
 use warnings;

--- a/lib/Shared/Examples/Net/Amazon/S3/API.pm
+++ b/lib/Shared/Examples/Net/Amazon/S3/API.pm
@@ -1,4 +1,5 @@
 package Shared::Examples::Net::Amazon::S3::API;
+# ABSTRACT: used for testing and as example
 
 use strict;
 use warnings;

--- a/lib/Shared/Examples/Net/Amazon/S3/Client.pm
+++ b/lib/Shared/Examples/Net/Amazon/S3/Client.pm
@@ -1,4 +1,5 @@
 package Shared::Examples::Net::Amazon::S3::Client;
+# ABSTRACT: used for testing and as example
 
 use strict;
 use warnings;

--- a/lib/Shared/Examples/Net/Amazon/S3/Error.pm
+++ b/lib/Shared/Examples/Net/Amazon/S3/Error.pm
@@ -1,4 +1,5 @@
 package Shared::Examples::Net::Amazon::S3::Error;
+# ABSTRACT: used for testing and as example
 
 use strict;
 use warnings;

--- a/lib/Shared/Examples/Net/Amazon/S3/Operation/Bucket/Create.pm
+++ b/lib/Shared/Examples/Net/Amazon/S3/Operation/Bucket/Create.pm
@@ -1,4 +1,5 @@
 package Shared::Examples::Net::Amazon::S3::Operation::Bucket::Create;
+# ABSTRACT: used for testing and as example
 
 use strict;
 use warnings;

--- a/lib/Shared/Examples/Net/Amazon/S3/Operation/Bucket/Objects/Delete.pm
+++ b/lib/Shared/Examples/Net/Amazon/S3/Operation/Bucket/Objects/Delete.pm
@@ -1,4 +1,5 @@
 package Shared::Examples::Net::Amazon::S3::Operation::Bucket::Objects::Delete;
+# ABSTRACT: used for testing and as example
 
 use strict;
 use warnings;

--- a/lib/Shared/Examples/Net/Amazon/S3/Operation/Bucket/Objects/List.pm
+++ b/lib/Shared/Examples/Net/Amazon/S3/Operation/Bucket/Objects/List.pm
@@ -1,4 +1,5 @@
 package Shared::Examples::Net::Amazon::S3::Operation::Bucket::Objects::List;
+# ABSTRACT: used for testing and as example
 
 use strict;
 use warnings;

--- a/lib/Shared/Examples/Net/Amazon/S3/Operation/Service/Buckets/List.pm
+++ b/lib/Shared/Examples/Net/Amazon/S3/Operation/Service/Buckets/List.pm
@@ -1,4 +1,5 @@
 package Shared::Examples::Net::Amazon::S3::Operation::Service::Buckets::List;
+# ABSTRACT: used for testing and as example
 
 use strict;
 use warnings;

--- a/lib/Shared/Examples/Net/Amazon/S3/Request.pm
+++ b/lib/Shared/Examples/Net/Amazon/S3/Request.pm
@@ -1,4 +1,5 @@
 package Shared::Examples::Net::Amazon::S3::Request;
+# ABSTRACT: used for testing and as example
 
 use strict;
 use warnings;


### PR DESCRIPTION
This fixes https://rt.cpan.org/Ticket/Display.html?id=125943 (and a few
more places that had duplicate NAME sections or were lacking an
abstract, which is essential when creating manpages out of POD).

Also, 'dzil build' will now run without the many "couldn't find abstract
in ..." warnings from PodWeaver