### PR TITLE
Support server side encryption also in Net::Amazon::S3::Bucket

### DIFF
--- a/lib/Net/Amazon/S3/Bucket.pm
+++ b/lib/Net/Amazon/S3/Bucket.pm
@@ -35,6 +35,11 @@ no strict 'vars'
     'x-amz-meta-colour' => 'orange',
   }));
 
+  # Enable server-side encryption
+  ok($bucket->add_key("key", "data", {
+     encryption => 'AES256',
+  }));
+
   # the err and errstr methods just proxy up to the Net::Amazon::S3's
   # objects err/errstr methods.
   $bucket->add_key("bar", "baz") or
@@ -123,12 +128,15 @@ sub add_key {
         delete $conf->{acl_short};
     }
 
+    my $encryption = delete $conf->{encryption};
+
     my $http_request = Net::Amazon::S3::Request::PutObject->new(
         s3        => $self->account,
         bucket    => $self->bucket,
         key       => $key,
         value     => $value,
         acl_short => $acl_short,
+        (encryption => $encryption) x!! defined $encryption,
         headers   => $conf,
     )->http_request;
 
@@ -206,6 +214,8 @@ sub copy_key {
 
     $conf->{'x-amz-copy-source'} = $source;
 
+    my $encryption = delete $conf->{encryption};
+
     my $acct    = $self->account;
     my $http_request = Net::Amazon::S3::Request::PutObject->new(
         s3        => $self->account,
@@ -213,6 +223,7 @@ sub copy_key {
         key       => $key,
         value     => '',
         acl_short => $acl_short,
+        (encryption => $encryption) x!! defined $encryption,
         headers   => $conf,
     )->http_request;
 

--- a/lib/Shared/Examples/Net/Amazon/S3.pm
+++ b/lib/Shared/Examples/Net/Amazon/S3.pm
@@ -368,6 +368,7 @@ sub expect_operation_object_create {
         qw[ with_content_disposition  ],
         qw[ with_content_encoding  ],
         qw[ with_content_type  ],
+        qw[ with_encryption ],
         qw[ with_expires ],
         qw[ with_storage_class  ],
         qw[ with_user_metadata ],

--- a/lib/Shared/Examples/Net/Amazon/S3/API.pm
+++ b/lib/Shared/Examples/Net/Amazon/S3/API.pm
@@ -209,6 +209,7 @@ sub operation_object_create {
         qw[ content_disposition  ],
         qw[ content_encoding  ],
         qw[ content_type  ],
+        qw[ encryption ],
         qw[ expires ],
         ;
 

--- a/lib/Shared/Examples/Net/Amazon/S3/Client.pm
+++ b/lib/Shared/Examples/Net/Amazon/S3/Client.pm
@@ -178,6 +178,7 @@ sub operation_object_create {
                 qw[ content_disposition  ],
                 qw[ content_encoding  ],
                 qw[ content_type  ],
+                qw[ encryption ],
                 qw[ expires ],
                 qw[ storage_class ],
                 qw[ user_metadata ],

--- a/t/api-object-create.t
+++ b/t/api-object-create.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 1 + 4;
+use Test::More tests => 1 + 5;
 use Test::Deep;
 use Test::Warnings;
 
@@ -26,6 +26,22 @@ expect_api_object_create 'create object from scalar value' => (
         content_length => 10,
         content_md5 => undef,
         expires => undef,
+    },
+);
+
+expect_api_object_create 'create object with server side encryption' => (
+    with_bucket             => 'some-bucket',
+    with_key                => 'some-key',
+    with_value              => 'some value',
+    with_encryption         => 'AES256',
+    expect_data             => bool (1),
+    expect_request          => { PUT => 'https://some-bucket.s3.amazonaws.com/some-key' },
+    expect_request_content  => 'some value',
+    expect_request_headers  => {
+        content_length => 10,
+        content_md5 => undef,
+        expires => undef,
+        x_amz_server_side_encryption => 'AES256',
     },
 );
 

--- a/t/client-object-create.t
+++ b/t/client-object-create.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 1 + 4;
+use Test::More tests => 1 + 5;
 use Test::Deep;
 use Test::Warnings;
 
@@ -27,6 +27,23 @@ expect_client_object_create 'create object from scalar value' => (
         content_length => 10,
         content_md5 => 'WUYhDJ6TrjeJHf6Ww+OWFA==',
         expires => undef,
+    },
+);
+
+expect_client_object_create 'create object from scalar value' => (
+    with_bucket             => 'some-bucket',
+    with_key                => 'some-key',
+    with_value              => 'some value',
+    with_encryption         => 'AES256',
+    with_response_headers   => { etag => '5946210c9e93ae37891dfe96c3e39614' },
+    expect_data             => '',
+    expect_request          => { PUT => 'https://some-bucket.s3.amazonaws.com/some-key' },
+    expect_request_content  => 'some value',
+    expect_request_headers  => {
+        content_length => 10,
+        content_md5 => 'WUYhDJ6TrjeJHf6Ww+OWFA==',
+        expires => undef,
+        x_amz_server_side_encryption => 'AES256',
     },
 );
 


### PR DESCRIPTION
Instead of passing x-amz header name (implementation) just pass
your intention with simple `encryption => 'AES256'`