### PR TITLE
Use '->' instead of '::' to fix Time::Piece issue where '::' doesn't …

### DIFF
--- a/lib/Net/Amazon/S3/Signature/V4Implementation.pm
+++ b/lib/Net/Amazon/S3/Signature/V4Implementation.pm
@@ -334,7 +334,7 @@ sub _format_amz_date {
 }
 
 sub _now {
-	return scalar Time::Piece::gmtime;
+	return scalar Time::Piece->gmtime;
 }
 
 sub _req_timepiece {


### PR DESCRIPTION
…produce a valid $_[0] that Time::Piece later references

This could be argued as a Time::Piece bug, but other references to Time::Piece use ->, why not this one?
