### PR TITLE
Fix setting of S3 XML document namespace

### DIFF
--- a/lib/Net/Amazon/S3.pm
+++ b/lib/Net/Amazon/S3.pm
@@ -814,7 +814,12 @@ sub _xpc_of_content {
     # warn $doc->toString(1);
 
     my $xpc = XML::LibXML::XPathContext->new($doc);
-    $xpc->registerNs( 's3', 'http://s3.amazonaws.com/doc/2006-03-01/' );
+
+    # Set default XML document NS as S3 namespace.
+    # Or default Amazon xmlns (for documents without NS).
+    my $s3_ns = $doc->documentElement->lookupNamespaceURI
+       || 'http://s3.amazonaws.com/doc/2006-03-01/';
+    $xpc->registerNs( 's3', $s3_ns );
 
     return $xpc;
 }

--- a/lib/Shared/Examples/Net/Amazon/S3.pm
+++ b/lib/Shared/Examples/Net/Amazon/S3.pm
@@ -43,6 +43,7 @@ sub s3_api_with_signature_4 {
 
 sub s3_api_with_signature_2 {
     Net::Amazon::S3->new (
+        @_,
         aws_access_key_id     => 'AKIDEXAMPLE',
         aws_secret_access_key => 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
         authorization_method  => 'Net::Amazon::S3::Signature::V2',

--- a/lib/Shared/Examples/Net/Amazon/S3/Operation/Bucket/Objects/List.pm
+++ b/lib/Shared/Examples/Net/Amazon/S3/Operation/Bucket/Objects/List.pm
@@ -12,6 +12,7 @@ our @EXPORT_OK = (
     qw[ list_bucket_objects_v1_with_filter ],
     qw[ list_bucket_objects_v1_with_delimiter ],
     qw[ list_bucket_objects_v1_with_prefix_and_delimiter ],
+    qw[ list_bucket_objects_v1_google_cloud_storage ],
 );
 
 sub list_bucket_objects_v1 {
@@ -164,6 +165,35 @@ sub list_bucket_objects_v1_with_prefix_and_delimiter {
   <CommonPrefixes>
     <Prefix>photos/2006/January/</Prefix>
   </CommonPrefixes>
+</ListBucketResult>
+EOXML
+}
+
+sub list_bucket_objects_v1_google_cloud_storage {
+    <<'EOXML';
+<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns='http://doc.s3.amazonaws.com/2006-03-01'>
+  <Name>gcs-bucket</Name>
+  <Prefix></Prefix>
+  <Marker></Marker>
+  <NextMarker>next/marker/is/foo</NextMarker>
+  <IsTruncated>true</IsTruncated>
+  <Contents>
+    <Key>path/to/value</Key>
+    <Generation>1473499153424000</Generation>
+    <MetaGeneration>1</MetaGeneration>
+    <LastModified>2017-04-21T22:06:03.413Z</LastModified>
+    <ETag>"1f52bad2879ca96dacd7a40f33001230"</ETag>
+    <Size>742213</Size>
+  </Contents>
+  <Contents>
+    <Key>path/to/value2</Key>
+    <Generation>1473499153424001</Generation>
+    <MetaGeneration>1</MetaGeneration>
+    <LastModified>2018-04-21T22:06:03.413Z</LastModified>
+    <ETag>"1f52bad2889ca96dacd7a40f33001230"</ETag>
+    <Size>742214</Size>
+  </Contents>
 </ListBucketResult>
 EOXML
 }


### PR DESCRIPTION
Issue is in fact, that AWS and GCS returns different XML namespace.
AWS returns:
`<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">`
GCS returns:
`<ListBucketResult xmlns='http://doc.s3.amazonaws.com/2006-03-01'>`

Signed-off-by: Michal Josef Špaček <michal.spacek@gooddata.com>