### PR TITLE
Support IAM role with STS credential for sign_uri().

### DIFF
--- a/lib/Net/Amazon/S3/Signature/V4.pm
+++ b/lib/Net/Amazon/S3/Signature/V4.pm
@@ -89,6 +89,12 @@ sub sign_request {
 sub sign_uri {
     my ($self, $request, $expires_at) = @_;
 
+    unless ($request->uri->query_param('x-amz-security-token')) {
+        my $aws_session_token = $self->http_request->s3->aws_session_token;
+        $request->uri->query_param('x-amz-security-token' => $aws_session_token)
+            if defined $aws_session_token;
+    }
+
     my $sign = $self->_sign;
     $self->_host_to_region_host( $sign, $request );
 


### PR DESCRIPTION
With 53713543e56ebcaea8389f18a368701c05d390fe, session token was supported for header request method, but query parameter method is not.

As I want to use query parameter method, made a patch for it (it works fine with my environment).