### PR TITLE
Allow passing headers from client to InitiateMultipartUpload request

### DIFF
--- a/lib/Net/Amazon/S3/Client/Object.pm
+++ b/lib/Net/Amazon/S3/Client/Object.pm
@@ -10,6 +10,7 @@ use MIME::Base64;
 use Moose::Util::TypeConstraints;
 use MooseX::Types::DateTime::MoreCoercions 0.07 qw( DateTime );
 use IO::File 1.14;
+use Ref::Util ();
 
 # ABSTRACT: An easy-to-use Amazon S3 client object
 
@@ -263,11 +264,13 @@ sub delete {
 
 sub initiate_multipart_upload {
     my $self = shift;
+    my %args = Ref::Util::is_plain_hashref($_[0]) ? %{$_[0]} : @_;
     my $http_request = Net::Amazon::S3::Request::InitiateMultipartUpload->new(
         s3     => $self->client->s3,
         bucket => $self->bucket->name,
         key    => $self->key,
         encryption => $self->encryption,
+        ($args{headers} ? (headers => $args{headers}) : ()),
     )->http_request;
     my $xpc = $self->client->_send_request_xpc($http_request);
     my $upload_id = $xpc->findvalue('//s3:UploadId');

--- a/t/request-initiate-multipart-upload.t
+++ b/t/request-initiate-multipart-upload.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 1 + 3;
+use Test::More tests => 5;
 use Test::Warnings;
 
 use Shared::Examples::Net::Amazon::S3::Request (
@@ -41,6 +41,18 @@ behaves_like_net_amazon_s3_request 'initiate multipart upload with service side 
     expect_request_method   => 'POST',
     expect_request_path     => 'some-bucket/some/key?uploads',
     expect_request_headers  => { 'x-amz-server-side-encryption' => 'AES256' },
+    expect_request_content  => '',
+);
+
+behaves_like_net_amazon_s3_request 'initiate multipart upload with headers' => (
+    request_class   => 'Net::Amazon::S3::Request::InitiateMultipartUpload',
+    with_bucket     => 'some-bucket',
+    with_key        => 'some/key',
+    with_headers    => { 'x-amz-meta-test' => 99 },
+
+    expect_request_method   => 'POST',
+    expect_request_path     => 'some-bucket/some/key?uploads',
+    expect_request_headers  => { 'x-amz-meta-test' => 99 },
     expect_request_content  => '',
 );
 


### PR DESCRIPTION
The [Initiate Multipart Upload documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/archive-mpUploadInitiate.html) allows specifying `x-amz-meta` headers, but currently the client doesn't allow arguments to be passed to the request object.

This allows them to pass through, allowing documents added by multipart uploading to contain any application specific custom headers.