### PR TITLE
404 should return false too

### DIFF
--- a/lib/Net/Amazon/S3/Error/Handler/Confess.pm
+++ b/lib/Net/Amazon/S3/Error/Handler/Confess.pm
@@ -17,6 +17,9 @@ my %return_false = (
 	NoSuchBucket => {
 		'Net::Amazon::S3::Operation::Object::Head::Response' => 1,
 	},
+	'404' => {
+                'Net::Amazon::S3::Operation::Object::Head::Response' => 1,
+        },
 );
 
 sub handle_error {


### PR DESCRIPTION
Net::Amazon::S3::Client::Object::exists dies instead of returning false

This fixes #98 