### PR TITLE
Fix missing Content-MD5 when deleting multiple objects

### DIFF
--- a/lib/Net/Amazon/S3/Operation/Objects/Delete/Request.pm
+++ b/lib/Net/Amazon/S3/Operation/Objects/Delete/Request.pm
@@ -8,6 +8,7 @@ extends 'Net::Amazon::S3::Request::Bucket';
 
 has 'keys'      => ( is => 'ro', isa => 'ArrayRef',   required => 1 );
 
+with 'Net::Amazon::S3::Request::Role::HTTP::Header::Content_md5';
 with 'Net::Amazon::S3::Request::Role::HTTP::Method::POST';
 with 'Net::Amazon::S3::Request::Role::Query::Action::Delete';
 with 'Net::Amazon::S3::Request::Role::XML::Content';

--- a/t/client-bucket-objects-delete.t
+++ b/t/client-bucket-objects-delete.t
@@ -26,6 +26,9 @@ expect_client_bucket_objects_delete 'delete multiple objects' => (
 	<Object><Key>key-2</Key></Object>
 </Delete>
 XML
+	expect_request_headers  => {
+		content_md5 => 'gAp9c7yOkifhnztMWAOlCg==',
+	},
 );
 
 expect_client_bucket_objects_delete 'S3 error - Access Denied' => (


### PR DESCRIPTION
When using `Net::Amazon::S3::Bucket::delete_multi_object`, the request will always fail as it's missing the required `Content-MD5` header (https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html).