### PR TITLE
Drop use of discouraged 'sort' pragma

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Revision history for Perl module Net::Amazon::S3:
 
 {{$NEXT}}
+	- Drop explicit use of 'sort' pragma, since this has been discouraged
 
 v0.991     2022-07-17
 	- Fix Signature V4 when uri contains tilde (issue #119, thanks marcusclip)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -69,7 +69,6 @@ my %WriteMakefileArgs = (
     "constant" => 0,
     "namespace::clean" => 0,
     "parent" => 0,
-    "sort" => 0,
     "strict" => 0,
     "warnings" => 0
   },
@@ -152,7 +151,6 @@ my %FallbackPrereqs = (
   "lib" => 0,
   "namespace::clean" => 0,
   "parent" => 0,
-  "sort" => 0,
   "strict" => 0,
   "utf8" => 0,
   "vars" => 0,

--- a/cpanfile
+++ b/cpanfile
@@ -51,7 +51,6 @@ requires "XML::LibXML::XPathContext" => "0";
 requires "constant" => "0";
 requires "namespace::clean" => "0";
 requires "parent" => "0";
-requires "sort" => "0";
 requires "strict" => "0";
 requires "warnings" => "0";
 recommends "VM::EC2::Security::CredentialCache" => "0";

--- a/lib/Net/Amazon/S3/Signature/V4Implementation.pm
+++ b/lib/Net/Amazon/S3/Signature/V4Implementation.pm
@@ -4,7 +4,6 @@ package Net::Amazon::S3::Signature::V4Implementation;
 
 use strict;
 use warnings;
-use sort 'stable';
 
 use Digest::SHA qw/sha256_hex hmac_sha256 hmac_sha256_hex/;
 use Time::Piece ();


### PR DESCRIPTION
As per https://perldoc.perl.org/sort:

> The sort pragma is now a no-op, and its use is discouraged