### PR TITLE
Pass Entire Client Bucket to Object Fetch Request

### DIFF
--- a/lib/Net/Amazon/S3/Client/Object.pm
+++ b/lib/Net/Amazon/S3/Client/Object.pm
@@ -363,7 +363,7 @@ sub uri {
 	my $self = shift;
 	return Net::Amazon::S3::Operation::Object::Fetch::Request->new (
 		s3     => $self->client->s3,
-		bucket => $self->bucket->name,
+		bucket => $self->bucket,
 		key    => $self->key,
 		method => 'GET',
 	)->http_request->uri;
@@ -378,7 +378,7 @@ sub query_string_authentication_uri_for_method {
 	my ($self, $method, $query_form) = @_;
 	return Net::Amazon::S3::Operation::Object::Fetch::Request->new (
 		s3     => $self->client->s3,
-		bucket => $self->bucket->name,
+		bucket => $self->bucket,
 		key    => $self->key,
 		method => $method,
 	)->query_string_authentication_uri ($self->expires->epoch, $query_form);


### PR DESCRIPTION
Similar to [#63 Use bucket region if available instead of HEAD region request](https://github.com/rustyconover/net-amazon-s3/pull/63)

Passing the entire object (rather than just the name) means the following won't have to perform a HEAD request, either:

```
  my $bucket = $client->bucket(
      name   => $bucket_name,
      region => "us-east-1",
  );

  my $object = $bucket->object(
      key     => $object_key,
      expires => time + 3600,
  );

  say $object->query_string_authentication_uri;
```