### PR TITLE
Fix precedence error (! vs =~)

### DIFF
--- a/lib/Net/Amazon/S3/Request/Role/HTTP/Header.pm
+++ b/lib/Net/Amazon/S3/Request/Role/HTTP/Header.pm
@@ -42,7 +42,7 @@ role {
 	has $name => (
 		is => 'ro',
 		isa => $params->constraint,
-		(init_arg => undef) x!! $name =~ m/^_/,
+		(init_arg => undef) x!! ($name =~ m/^_/),
 		required => $params->required,
 		(default => $params->default) x!! defined $params->default,
 	);


### PR DESCRIPTION
`!! $name =~ m/^_/` is parsed as `(!!$name) =~ m/^_/`, not the intended `!! ($name =~ m/^_/)`.